### PR TITLE
Log is called twistd.log

### DIFF
--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -191,7 +191,7 @@ It should end with lines like these:
   2014-11-01 15:56:51+0100 [Broker,client] message from master: attached
   The worker appears to have (re)started correctly.
 
-Meanwhile, from the other terminal, in the master log (:file:`twisted.log` in the master directory), you should see lines like these:
+Meanwhile, from the other terminal, in the master log (:file:`twistd.log` in the master directory), you should see lines like these:
 
 .. code-block:: none
 


### PR DESCRIPTION
I'm going through the tutorial for 2.7.0 and noticed that the log is called `twistd.log` and not `twisted.log`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
